### PR TITLE
make command line interface compatible with Google's C code

### DIFF
--- a/src/java/com/rondhuit/w2v/demo/AbstractCreateVectors.java
+++ b/src/java/com/rondhuit/w2v/demo/AbstractCreateVectors.java
@@ -66,17 +66,17 @@ public abstract class AbstractCreateVectors {
   
   protected void setConfig(String[] args, Config config){
     int i;
-    if((i = argPos("-size", args)) >= 0) config.setLayer1Size(Integer.parseInt(args[i + 1]));
-    if((i = argPos("-output", args)) >= 0) config.setOutputFile(args[i + 1]);
-    if((i = argPos("-cbow", args)) >= 0) config.setUseContinuousBagOfWords(true);
-    if(config.useContinuousBagOfWords()) config.setAlpha(0.05f);
-    if((i = argPos("-alpha", args)) >= 0) config.setAlpha(Float.parseFloat(args[i + 1]));
-    if((i = argPos("-window", args)) >= 0) config.setWindow(Integer.parseInt(args[i + 1]));
-    if((i = argPos("-sample", args)) >= 0) config.setSample(Float.parseFloat(args[i + 1]));
-    if((i = argPos("-hs", args)) >= 0) config.setUseHierarchicalSoftmax(true);
-    if((i = argPos("-negative", args)) >= 0) config.setNegative(Integer.parseInt(args[i + 1]));
-    if((i = argPos("-threads", args)) >= 0) config.setNumThreads(Integer.parseInt(args[i + 1]));
-    if((i = argPos("-iter", args)) >= 0) config.setIter(Integer.parseInt(args[i + 1]));
-    if((i = argPos("-min-count", args)) >= 0) config.setMinCount(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-size", args)) >= 0) config.setLayer1Size(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-output", args)) >= 0) config.setOutputFile(args[i + 1]);
+    if ((i = argPos("-cbow", args)) >= 0) config.setUseContinuousBagOfWords(Integer.parseInt(args[i + 1]) == 1);
+    if (config.useContinuousBagOfWords()) config.setAlpha(0.05f);
+    if ((i = argPos("-alpha", args)) >= 0) config.setAlpha(Float.parseFloat(args[i + 1]));
+    if ((i = argPos("-window", args)) >= 0) config.setWindow(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-sample", args)) >= 0) config.setSample(Float.parseFloat(args[i + 1]));
+    if ((i = argPos("-hs", args)) >= 0) config.setUseHierarchicalSoftmax(Integer.parseInt(args[i + 1]) == 1);
+    if ((i = argPos("-negative", args)) >= 0) config.setNegative(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-threads", args)) >= 0) config.setNumThreads(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-iter", args)) >= 0) config.setIter(Integer.parseInt(args[i + 1]));
+    if ((i = argPos("-min-count", args)) >= 0) config.setMinCount(Integer.parseInt(args[i + 1]));
   }
 }


### PR DESCRIPTION
Hi Mr. Sekiguchi.

I find that the command line parsing logic is different with the original C code:

```
if ((i = ArgPos((char *)"-cbow", argc, argv)) > 0) cbow = atoi(argv[i + 1]);
  
if ((i = ArgPos((char *)"-hs", argc, argv)) > 0) hs = atoi(argv[i + 1]);
```
  
which causes different scores when using the same parameters with original C version. Depending on whether you want to follow Google fashion, you may want to merge it .

One related issue is https://github.com/kojisekig/word2vec-lucene/issues/21 .